### PR TITLE
r.buffer: Add test script

### DIFF
--- a/raster/r.buffer/testsuite/test_buffer.py
+++ b/raster/r.buffer/testsuite/test_buffer.py
@@ -1,0 +1,88 @@
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+from grass.gunittest.gmodules import SimpleModule
+import grass.script as gs
+
+
+class TestRBuffer(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.use_temp_region()
+        cls.runModule("g.region", raster="elevation")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.del_temp_region()
+
+    def test_buffer_creation(self):
+        output = "buf_test"
+        distances = [100, 200, 300, 400, 500]
+
+        module = SimpleModule("r.buffer", input="elevation", output=output,
+                              distances=distances, overwrite=True)
+        self.assertModule(module)
+
+        self.assertRasterExists(output)
+
+        expected_categories = [1] + [i + 1 for i in range(len(distances))]
+
+        self.assertRasterMinMax(
+            map=output,
+            refmin=min(expected_categories),
+            refmax=max(expected_categories),
+            msg=("Buffer zones should have category values from 1 to " + #Checking if there are no abnormal values in the output raster map
+                 str(max(expected_categories)))
+        )
+
+        category_values = gs.read_command("r.stats", flags="n", input=output).splitlines()
+        category_values = [int(line.split()[0]) for line in category_values]
+
+        print("Category values:", category_values)
+
+        unique_actual_categories = set(category_values)
+        self.assertTrue(
+            unique_actual_categories.issubset(set(expected_categories)),
+            msg=("Output categories should be a subset of expected categories: " +
+                 str(expected_categories))
+        )
+
+    def test_no_non_null_values(self):
+        null_map = "null_map"
+        self.runModule("r.mapcalc", expression=f"{null_map} = null()")
+
+        output = "buf_no_non_null"
+        distances = [100, 200, 300]
+
+        module = SimpleModule("r.buffer", input=null_map, output=output,
+                              distances=distances, overwrite=True)
+        self.assertModule(module)
+
+        self.assertRasterExists(output)
+        stats = gs.read_command("r.univar", map=output, flags="g")
+        self.assertIn("n=0", stats, msg="Output should have no non-NULL cells") # Checking an edge case where the input raster map is null
+
+    def test_ignore_zero_values(self):
+        zero_map = "zero_map"
+        self.runModule("r.mapcalc", expression=f"{zero_map} = if(row() % 2 == 0, 0, 1)")
+
+        output = "buf_ignore_zero"
+        distances = [100, 200]
+
+        module = SimpleModule("r.buffer", input=zero_map, output=output,
+                              distances=distances, flags="z", overwrite=True)
+        self.assertModule(module)
+
+        self.assertRasterExists(output)
+
+        category_values = gs.read_command("r.stats", flags="n", input=output).splitlines()
+        category_values = [int(line.split()[0]) for line in category_values]
+
+        print("Category values:", category_values)
+
+        self.assertNotIn(0, category_values,
+                         msg="Output should not contain buffer zones around zero values") # Check if the output raster map ignored 0 values
+
+
+if __name__ == "__main__":
+    test()

--- a/raster/r.buffer/testsuite/test_buffer.py
+++ b/raster/r.buffer/testsuite/test_buffer.py
@@ -9,23 +9,28 @@ class TestRBuffer(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.use_temp_region()
-        cls.runModule("g.region", raster="elevation")
+        cls.runModule("g.region", raster="roadsmajor")
 
     @classmethod
     def tearDownClass(cls):
         cls.del_temp_region()
 
+    def tearDown(self):
+        # Remove temporary maps created during tests
+        gs.run_command('g.remove', type='raster',
+                       name='null_map,zero_map,buf_test,buf_no_non_null,buf_ignore_zero', flags='f')
+
     def test_buffer_creation(self):
         output = "buf_test"
         distances = [100, 200, 300, 400, 500]
 
-        module = SimpleModule("r.buffer", input="elevation", output=output,
+        module = SimpleModule("r.buffer", input="roadsmajor", output=output,
                               distances=distances, overwrite=True)
         self.assertModule(module)
 
         self.assertRasterExists(output)
 
-        expected_categories = [1] + [i + 1 for i in range(len(distances))]
+        expected_categories = [1] + [i + 1 for i in range(len(distances)+1)]
 
         self.assertRasterMinMax(
             map=output,

--- a/raster/r.buffer/testsuite/test_buffer.py
+++ b/raster/r.buffer/testsuite/test_buffer.py
@@ -17,30 +17,43 @@ class TestRBuffer(TestCase):
 
     def tearDown(self):
         # Remove temporary maps created during tests
-        gs.run_command('g.remove', type='raster',
-                       name='null_map,zero_map,buf_test,buf_no_non_null,buf_ignore_zero', flags='f')
+        gs.run_command(
+            "g.remove",
+            type="raster",
+            name="null_map,zero_map,buf_test,buf_no_non_null,buf_ignore_zero",
+            flags="f",
+        )
 
     def test_buffer_creation(self):
         output = "buf_test"
         distances = [100, 200, 300, 400, 500]
 
-        module = SimpleModule("r.buffer", input="roadsmajor", output=output,
-                              distances=distances, overwrite=True)
+        module = SimpleModule(
+            "r.buffer",
+            input="roadsmajor",
+            output=output,
+            distances=distances,
+            overwrite=True,
+        )
         self.assertModule(module)
 
         self.assertRasterExists(output)
 
-        expected_categories = [1] + [i + 1 for i in range(len(distances)+1)]
+        expected_categories = [1] + [i + 1 for i in range(len(distances) + 1)]
 
         self.assertRasterMinMax(
             map=output,
             refmin=min(expected_categories),
             refmax=max(expected_categories),
-            msg=("Buffer zones should have category values from 1 to " + #Checking if there are no abnormal values in the output raster map
-                 str(max(expected_categories)))
+            msg=(
+                "Buffer zones should have category values from 1 to "  # Checking if there are no abnormal values in the output raster map
+                + str(max(expected_categories))
+            ),
         )
 
-        category_values = gs.read_command("r.stats", flags="n", input=output).splitlines()
+        category_values = gs.read_command(
+            "r.stats", flags="n", input=output
+        ).splitlines()
         category_values = [int(line.split()[0]) for line in category_values]
 
         print("Category values:", category_values)
@@ -48,8 +61,10 @@ class TestRBuffer(TestCase):
         unique_actual_categories = set(category_values)
         self.assertTrue(
             unique_actual_categories.issubset(set(expected_categories)),
-            msg=("Output categories should be a subset of expected categories: " +
-                 str(expected_categories))
+            msg=(
+                "Output categories should be a subset of expected categories: "
+                + str(expected_categories)
+            ),
         )
 
     def test_no_non_null_values(self):
@@ -59,13 +74,20 @@ class TestRBuffer(TestCase):
         output = "buf_no_non_null"
         distances = [100, 200, 300]
 
-        module = SimpleModule("r.buffer", input=null_map, output=output,
-                              distances=distances, overwrite=True)
+        module = SimpleModule(
+            "r.buffer",
+            input=null_map,
+            output=output,
+            distances=distances,
+            overwrite=True,
+        )
         self.assertModule(module)
 
         self.assertRasterExists(output)
         stats = gs.read_command("r.univar", map=output, flags="g")
-        self.assertIn("n=0", stats, msg="Output should have no non-NULL cells") # Checking an edge case where the input raster map is null
+        self.assertIn(
+            "n=0", stats, msg="Output should have no non-NULL cells"
+        )  # Checking an edge case where the input raster map is null
 
     def test_ignore_zero_values(self):
         zero_map = "zero_map"
@@ -74,19 +96,30 @@ class TestRBuffer(TestCase):
         output = "buf_ignore_zero"
         distances = [100, 200]
 
-        module = SimpleModule("r.buffer", input=zero_map, output=output,
-                              distances=distances, flags="z", overwrite=True)
+        module = SimpleModule(
+            "r.buffer",
+            input=zero_map,
+            output=output,
+            distances=distances,
+            flags="z",
+            overwrite=True,
+        )
         self.assertModule(module)
 
         self.assertRasterExists(output)
 
-        category_values = gs.read_command("r.stats", flags="n", input=output).splitlines()
+        category_values = gs.read_command(
+            "r.stats", flags="n", input=output
+        ).splitlines()
         category_values = [int(line.split()[0]) for line in category_values]
 
         print("Category values:", category_values)
 
-        self.assertNotIn(0, category_values,
-                         msg="Output should not contain buffer zones around zero values") # Check if the output raster map ignored 0 values
+        self.assertNotIn(
+            0,
+            category_values,
+            msg="Output should not contain buffer zones around zero values",
+        )  # Check if the output raster map ignored 0 values
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds regression tests for the `r.buffer` module to ensure its functionality remains intact with future code changes. The following test cases are covered:

**test_buffer_creation():** Verifies the creation of buffer zones around raster features based on specified distances. It checks that the output raster exists, has expected category values starting from 1, and that the minimum and maximum values match the expected range.

**test_no_non_null_values():** Confirms that the `r.buffer` module correctly handles an input raster that is entirely null, ensuring the output contains no non-null values.

**test_ignore_zero_values():** Ensures that zero values in the input raster are ignored when creating buffer zones, resulting in an output that does not include any zero categories.